### PR TITLE
Specify the column name

### DIFF
--- a/src/Foxted/Permissions/Traits/Can.php
+++ b/src/Foxted/Permissions/Traits/Can.php
@@ -13,7 +13,7 @@ trait Can
      */
     public function role()
 	{
-		return $this->belongsTo('\Foxted\Permissions\Role');
+		return $this->belongsTo('\Foxted\Permissions\Role', 'roles_id');
 	}
 
     /**


### PR DESCRIPTION
specify the column name because Eloquent look for a role_id column on
the users table and can't find anything